### PR TITLE
Detection whether session is successfully opened

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -529,7 +529,7 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 	}
 
 	rc = ioctl(ctx->fd, TEE_IOC_OPEN_SESSION, &buf_data);
-	if (rc) {
+	if (!arg->ret || rc) {
 		EMSG("TEE_IOC_OPEN_SESSION failed");
 		eorig = TEEC_ORIGIN_COMMS;
 		res = ioctl_errno_to_res(errno);

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -529,7 +529,7 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 	}
 
 	rc = ioctl(ctx->fd, TEE_IOC_OPEN_SESSION, &buf_data);
-	if (!arg->ret || rc) {
+	if (arg->ret || rc) {
 		EMSG("TEE_IOC_OPEN_SESSION failed");
 		eorig = TEEC_ORIGIN_COMMS;
 		res = ioctl_errno_to_res(errno);


### PR DESCRIPTION
The return value of the ioctl() function does not represent the case where open_session fails due to a panick. 
arg->ret is a flag indicating whether the session was successfully opened.